### PR TITLE
Fix: moveEvent class unimplemented KeyError

### DIFF
--- a/pysui/sui/sui_types.py
+++ b/pysui/sui/sui_types.py
@@ -1212,6 +1212,18 @@ class PublishEvent(SuiTxReturnType, DataClassJsonMixin):
     sender: str
 
 
+@dataclass
+class MoveEvent(SuiTxReturnType, DataClassJsonMixin):
+    """Event Type."""
+
+    package_id: str = field(metadata=config(letter_case=LetterCase.CAMEL))
+    transaction_module: str = field(metadata=config(letter_case=LetterCase.CAMEL))
+    sender: str
+    type: str = field(metadata=config(letter_case=LetterCase.CAMEL))
+    bcs: str
+    fields: dict
+
+
 _EVENT_LOOKUP = {
     "coinBalanceChange": CoinBalanceChangeEvent,
     "newObject": NewObjectEvent,
@@ -1221,6 +1233,7 @@ _EVENT_LOOKUP = {
     "epochChange": EpochChangeEvent,
     "newCheckPoint": NewCheckpointEvent,
     "publish": PublishEvent,
+    "moveEvent": MoveEvent,
 }
 
 


### PR DESCRIPTION
## Explanation
When trying to run a `client.move_call_txn(**kwargs)` on a NFT mint, the `moveEvent` isn't handled. Leads to a keyError found below.
<img width="498" alt="Screen Shot 2022-12-14 at 1 27 37 PM" src="https://user-images.githubusercontent.com/39306557/207678659-6bc7325a-29ef-4f6b-9ea4-73b0a8730a75.png">


## Solution
Implemented the `MoveEvent` class and added it to the `_EVENT_LOOKUP` dict. Class was implemented based off of the moveEvent below. 

```
{
   "moveEvent" : {
      "packageId" : string "0x0000000000000000000000000000000000000002",
      "transactionModule" :  string "devnet_nft",
      "sender" : string "0xd09945b37728c1555592c03ccd6c66dd1ede4899",
      "type" : string "0x2::devnet_nft::MintNFTEvent",
      "fields" : {
         "creator" : string "0xd09945b37728c1555592c03ccd6c66dd1ede4899",
         "name" : string "testing101",
         "object_id" : string "0x2861ba000fdc3a1fa5087c38babc1a0ba5f42069",
      }
      "bcs" : string "KGG6AA/cOh+lCHw4urwaC6X0IGnQmUWzdyjBVVWSwDzNbGbdHt5ImQp0ZXN0aW5nMTAx"
}
```

Full transaction information can be found here: https://suiscan.xyz/devnet/transaction/8s8sjfygXNVH5V7Zjkye5iYzygatAZvmRYXgCwXEpDRV under `Events/Raw`