### PR TITLE
fixes #129

### DIFF
--- a/pysui/sui/sui_builders/exec_builders.py
+++ b/pysui/sui/sui_builders/exec_builders.py
@@ -408,7 +408,7 @@ class SplitCoin(_MoveCallTransactionBuilder):
         signer: SuiAddress,
         coin_object_id: ObjectID,
         split_amounts: SuiArray[SuiString],
-        gas_object: ObjectID,
+        gas: ObjectID,
         gas_budget: SuiString,
     ) -> None:
         """__init__ SplitCoin Builder initializer.


### PR DESCRIPTION
fixes #129 

inside `class SplitCoin(_MoveCallTransactionBuilder):`, the `gas_object` parameter was causing issues. changed to `gas`. this is also consistent with how MergeCoin handles this.