### PR TITLE
fix from_type_str for TypeTag

### DIFF
--- a/pysui/sui/sui_types/bcs.py
+++ b/pysui/sui/sui_types/bcs.py
@@ -15,14 +15,15 @@
 
 import binascii
 from typing import Any, Union
-import canoser
-from deprecated.sphinx import versionadded, versionchanged, deprecated
-from pysui.abstracts.client_keypair import SignatureScheme, PublicKey
-from pysui.sui.sui_txresults.single_tx import ObjectRead
 
-from pysui.sui.sui_types.address import SuiAddress
-from pysui.sui.sui_utils import hexstring_to_list, b58str_to_list
+import canoser
+from deprecated.sphinx import deprecated, versionadded, versionchanged
+
+from pysui.abstracts.client_keypair import PublicKey, SignatureScheme
 from pysui.sui.sui_txresults.common import GenericRef
+from pysui.sui.sui_txresults.single_tx import ObjectRead
+from pysui.sui.sui_types.address import SuiAddress
+from pysui.sui.sui_utils import b58str_to_list, hexstring_to_list
 
 _ADDRESS_LENGTH: int = 32
 _DIGEST_LENGTH: int = 32
@@ -356,11 +357,13 @@ class StructTag(canoser.Struct):
                 lowest_level = _reducer(lowest_level, last_one)
             # Return the main struct tag container
             main_struct = multi_struct[0].split("::")
+            if not isinstance(lowest_level, list):
+                lowest_level = [lowest_level]
             return cls(
                 Address.from_str(main_struct[0]),
                 main_struct[1],
                 main_struct[2],
-                [lowest_level] if not isinstance(lowest_level, list) else lowest_level,
+                lowest_level,
             )
         split_type = type_str.split("::")
         return cls(Address.from_str(split_type[0]), split_type[1], split_type[2], [])

--- a/pysui/sui/sui_types/bcs.py
+++ b/pysui/sui/sui_types/bcs.py
@@ -15,7 +15,6 @@
 
 import binascii
 from typing import Any, Union
-from functools import reduce
 import canoser
 from deprecated.sphinx import versionadded, versionchanged, deprecated
 from pysui.abstracts.client_keypair import SignatureScheme, PublicKey
@@ -325,7 +324,7 @@ class StructTag(canoser.Struct):
 
         def _reducer(accum: Union[TypeTag, list[TypeTag]], item: str) -> TypeTag:
             """Accumulate nested type tags."""
-            new_s = item.split("::")
+            new_s = item.strip().split("::")
             if not accum:
                 return TypeTag(
                     "Struct",
@@ -361,7 +360,7 @@ class StructTag(canoser.Struct):
                 Address.from_str(main_struct[0]),
                 main_struct[1],
                 main_struct[2],
-                [lowest_level],
+                [lowest_level] if not isinstance(lowest_level, list) else lowest_level,
             )
         split_type = type_str.split("::")
         return cls(Address.from_str(split_type[0]), split_type[1], split_type[2], [])


### PR DESCRIPTION
- strip value in `_reducer` as it can have an extra space after splitting by `,`;
- pass `lowest_level` as is if it's a list, otherwise it leads to an issue for types that have their own type tag;

Here is an example type that will be parsed correctly, without this fix it will fail
```
0xb24b6789e088b876afabca733bed2299fbc9e2d6369be4d1acfa17d8145454d9::swap::LSP<0x2::sui::SUI, 0x239e9725bdab1fcb2e4798a057da809e52f13134a09bc9913659d4a80ddfdaad::shui::SHUI>
```
