### PR TITLE
fix `type_arg` parsing

### DIFF
--- a/pysui/sui/sui_txresults/single_tx.py
+++ b/pysui/sui/sui_txresults/single_tx.py
@@ -16,10 +16,12 @@
 
 from dataclasses import dataclass, field
 from typing import Any, Optional, Union
-from dataclasses_json import DataClassJsonMixin, config, LetterCase
+
+from dataclasses_json import DataClassJsonMixin, LetterCase, config
 from deprecated.sphinx import versionchanged
-from pysui.sui.sui_types import ObjectID, SuiAddress
+
 from pysui.sui.sui_txresults.common import GenericRef
+from pysui.sui.sui_types import ObjectID, SuiAddress
 
 # pylint:disable=too-many-instance-attributes
 # Faucet results
@@ -61,11 +63,7 @@ class ObjectReadData(DataClassJsonMixin):
         """Post init processing for parameters."""
         ref = self.type_.split("<", 1)
         if len(ref) > 1:
-            inner_ref = ref[1][:-1].split(",")
-            if len(inner_ref) > 1:
-                self.type_arg = [x.strip() for x in inner_ref]
-            else:
-                self.type_arg = ref[1][:-1]
+            self.type_arg = ref[1][:-1]
         if "id" in self.fields:
             self.fields["id"] = self.fields["id"]["id"]
 

--- a/pysui/sui/sui_txresults/single_tx.py
+++ b/pysui/sui/sui_txresults/single_tx.py
@@ -59,7 +59,7 @@ class ObjectReadData(DataClassJsonMixin):
 
     def __post_init__(self):
         """Post init processing for parameters."""
-        ref = self.type_.split("<")
+        ref = self.type_.split("<", 1)
         if len(ref) > 1:
             inner_ref = ref[1][:-1].split(",")
             if len(inner_ref) > 1:


### PR DESCRIPTION
- always return `str` in `type_arg` at it's the correct type (that can then be correctly parsed by `TypeTag`)

This one is opinionated but I am not sure how we would benefit from having an array in `type_arg` (may be rename it to `type_args` then?).  Anyway this type currently

```
0xa283fd6b45f1103176e7ae27e870c89df7c8783b15345e2b13faa81ec25c4fa6::protocol::Contract<0xb24b6789e088b876afabca733bed2299fbc9e2d6369be4d1acfa17d8145454d9::swap::LSP<0x2::sui::SUI, 0x239e9725bdab1fcb2e4798a057da809e52f13134a09bc9913659d4a80ddfdaad::shui::SHUI>>
```

Is parsed just as `0xb24b6789e088b876afabca733bed2299fbc9e2d6369be4d1acfa17d8145454d9::swap::LS` by pysui which for sure is incorrect.