### PR TITLE
fix str length encoding

### DIFF
--- a/pysui/sui/sui_txn/transaction_builder.py
+++ b/pysui/sui/sui_txn/transaction_builder.py
@@ -193,9 +193,9 @@ class PureInput:
     def _(cls, arg: str) -> list:
         """Convert str to list of bytes."""
         logger.debug(f"str->pure {arg}")
-        base_list = list(bytearray(arg, encoding="utf-8"))
-        base_list.insert(0, len(base_list))
-        return base_list
+        byte_list = list(bytearray(arg, encoding="utf-8"))
+        length_prefix = list(bytearray(serialize_uint32_as_uleb128(None, len(byte_list))))
+        return length_prefix + byte_list
 
     @pure.register
     @classmethod


### PR DESCRIPTION
Encountered an error while trying to make a transaction with a long string argument:
```
  File ".venv/lib/python3.11/site-packages/canoser/array_t.py", line 45, in check_value
    self.atype.check_value(item)
  File ".venv/lib/python3.11/site-packages/canoser/int_type.py", line 72, in check_value
    raise TypeError('value {} not in range {}-{}'.format(value, min, max))
TypeError: value 871 not in range 0-255
```

Traced the issue back to the encoding of string length.