### PR TITLE
Update graphql.rst

### DIFF
--- a/doc/source/graphql.rst
+++ b/doc/source/graphql.rst
@@ -51,7 +51,7 @@ Simple dev example
 
     from pysui.sui.sui_pgql.clients import SuiGQLClient
     import pysui.sui.sui_pgql.pgql_query as qn
-    from pysui import SuiConfig
+    from pysui import SuiConfig,handle_result
 
     def main(client: SuiGQLClient):
         """Fetch 0x2::sui::SUI (default) for owner."""
@@ -61,8 +61,13 @@ Simple dev example
                 owner="0x00878369f475a454939af7b84cdd981515b1329f159a1aeb9bf0f8899e00083a"
             )
         )
-        # QueryNode results are mapped to dataclasses/dataclasses-json
-        print(qres.to_json(indent=2))
+        # 1. QueryNode results are mapped to dataclasses/dataclasses-json
+        print(qres.result_data.to_json(indent=2))
+
+        # 2. Or get the data through handle_result
+        # print(handle_result(qres).to_json(indent=2))
+
+    
 
     if __name__ == "__main__":
         # Initialize synchronous client


### PR DESCRIPTION
Problems:
    The qres object does not have a to_json method.
Solutions:
    1. Get the result_data of qres, and then you can use the to_json method.
    2. Or process the data by using handle_result, and then use the to_json method.