### PR TITLE
Allow recovery of an account via the mnemonic even if it is already in SuiConfig

### DIFF
--- a/pysui/sui/sui_config.py
+++ b/pysui/sui/sui_config.py
@@ -368,7 +368,6 @@ class SuiConfig(ClientConfiguration):
             If not provide, alias will be generated
         :type alias: Optional[str], optional
         :raises NotImplementedError: When providing unregognized scheme
-        :raises ValueError: If recovered keypair/address already exists
         :return: The input mnemonic string and the new keypair associated SuiAddress
         :rtype: tuple[str, SuiAddress]
         """
@@ -384,7 +383,8 @@ class SuiConfig(ClientConfiguration):
                     scheme, mnemonics, derivation_path
                 )
                 if address.address in self.addresses:
-                    raise ValueError(f"Address {address.address} already exists.")
+                    # already exists, nothing more to do
+                    return mnem, address
                 # Valid Sui base64 keystring
                 kpstr = keypair.serialize()
                 # Valid type encoded base64 Sui public key


### PR DESCRIPTION
Currently when you call SuiConfig.recover_keypair_and_address with a mnemonic (to recover an account), a ValueError will be raised, indicating that the key already exists.  However the function does not inform you of the account address.  This leaves the caller unaware of the address, and they can't make use of the account or recover it -- short of just creating a new SuiConfig.  Instead of raising a ValueError, the mnemonic and address is just returned, since it was already created.  