### PR TITLE
Fix `Event.parsed_json` type (str -> dict)

### DIFF
--- a/pysui/sui/sui_txresults/complex_tx.py
+++ b/pysui/sui/sui_txresults/complex_tx.py
@@ -219,7 +219,7 @@ class Event(SuiTxReturnType, DataClassJsonMixin):
 
     bcs: str
     package_id: str = field(metadata=config(letter_case=LetterCase.CAMEL))
-    parsed_json: str = field(metadata=config(letter_case=LetterCase.CAMEL))
+    parsed_json: dict = field(metadata=config(letter_case=LetterCase.CAMEL))
     sender: str
     transaction_module: str = field(metadata=config(letter_case=LetterCase.CAMEL))
     event_type: str = field(metadata=config(field_name="type"))


### PR DESCRIPTION
Fixes `parsed_json` incorrectly being an `str` that represents a python `dict` as such: `"{'beneficiary': '...', 'buyer': '...', [...]}"`