### PR TITLE
Fix bug in sui_tryGetPastObjects jrpc call

### DIFF
--- a/pysui/sui/sui_types/collections.py
+++ b/pysui/sui/sui_types/collections.py
@@ -119,6 +119,11 @@ class SuiArray(SuiCollection, Generic[AT]):
         """Alias for transactions."""
         return self.array
 
+    @property
+    def past_objects(self) -> list[dict]:
+        """Alias for transactions."""
+        return self.array
+
 
 @deprecated(
     version="0.65.0", reason="Transition to pysui GraphQL SuiClients and QueryNodes"


### PR DESCRIPTION
Added another alias for SuiArray so it could be used in the `sui_tryGetPastObjects` builder