### PR TITLE
Added forgotten parameter

### DIFF
--- a/pysui/sui/sui_pgql/pgql_utils.py
+++ b/pysui/sui/sui_pgql/pgql_utils.py
@@ -289,5 +289,5 @@ async def async_get_objects_by_ids(
     :rtype: list[pgql_type.ObjectReadGQL]
     """
     return await async_cursored_collector(
-        partial(qn.GetMultipleObjects, object_ids=object_ids), only_active
+        partial(qn.GetMultipleObjects, object_ids=object_ids), client, only_active
     )


### PR DESCRIPTION
Just use you library for interaction with bluefin protocol and receive strange error:
```
  File ".../pools_worker/src/clients/sui_client.py", line 52, in get_objects_by_ids
    return await async_get_objects_by_ids(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/.../Library/Caches/pypoetry/virtualenvs/pools-worker-VhsiMrLX-py3.12/lib/python3.12/site-packages/pysui/sui/sui_pgql/pgql_utils.py", line 291, in async_get_objects_by_ids
    return await async_cursored_collector(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/.../Library/Caches/pypoetry/virtualenvs/pools-worker-VhsiMrLX-py3.12/lib/python3.12/site-packages/pysui/sui/sui_pgql/pgql_utils.py", line 92, in async_cursored_collector
    result = await client.execute_query_node(with_node=pfn())
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'execute_query_node'
```

If i understood everything correctly you just forgot to add a parameter to the function call