### PR TITLE
chore: upgrade httpx dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.89.1] - 2025-09-09
+
+### Changed
+
+- upgrade httpx dependency
+
 ## [0.89.0] - 2025-09-01
 
 ### Added
@@ -32,7 +38,7 @@ GraohQL client constructor and execute methods.
 ### Added
 
 - gRPC: VerifySignature request
-- [change](https://github.com/FrankC01/pysui/issues/333) gRPC: `txn_expires_after: Optional[int] = None` to SimulateTransactionLKind request 
+- [change](https://github.com/FrankC01/pysui/issues/333) gRPC: `txn_expires_after: Optional[int] = None` to SimulateTransactionLKind request
 
 ### Fixed
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -38,7 +38,7 @@ Requires:
 
 `pip install -r requirements.txt`
 
-### Load anciallary development packages
+### Load ancillary development packages
 
 `pip install -r requirements-dev.txt` .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ testpaths = ["tests", "tests/sync_tests", "tests/integration_sync"]
 pythonpath = ["pysui", "abstracts", "sui", "sui/sui_types"]
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel","setuptools-scm>=8.0"]
+requires = ["setuptools>=61.0", "wheel", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pysui/version.py
+++ b/pysui/version.py
@@ -4,5 +4,7 @@
 # -*- coding: utf-8 -*-
 
 # Read in command line and posting to PyPi
-__version__ = "0.89.0"
+
+
+__version__ = "0.89.1"
 """Pysui Version."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-betterproto2[grpclib] < 1.0.0, >= 0.8.0s
+betterproto2[grpclib] < 1.0.0, >= 0.8.0
 dataclasses_json < 0.7.0, >= 0.6.6
 pyyaml < 6.2, >= 6.0.1
-httpx < 0.28, >=0.27.0
+httpx < 0.29, >=0.28.1
 h2 < 5, >= 4.1.0
 pysui-fastcrypto >= 0.6.0
 jsonschema < 4.30, >= 4.23.0


### PR DESCRIPTION
Upgrade `httpx` dependency to 0.28.1. This unlocks integration of `pysui` with other packages that depend on newer versions of httpx. I've read through the associated CHANGELOG, and it looks like `pysui` is compatible with the changes to the `verify=` parameters. https://github.com/encode/httpx/blob/master/CHANGELOG.md