### PR TITLE
[Add] Updated address.py to have a magic address that prints the sui address

### DIFF
--- a/pysui/sui/sui_types/address.py
+++ b/pysui/sui/sui_types/address.py
@@ -39,6 +39,10 @@ class SuiAddress(SuiBaseType):
         # Alias for transaction validation
         self.address = testvalid
 
+    def __repr__(self):
+        #return the sui address 
+        return f" Sui address= {self.address}"
+
     @property
     def signer(self) -> str:
         """Alias for signer in transaction validation."""


### PR DESCRIPTION
Hello! i and my friend @danxcrusher wanted to create a new address using pysui then noticed that it prints the object's memory address instead of the actual address, so we added a magic method that prints out the sui address when self.address is called instead of the object's memory address