### PR TITLE
fix: remove duplicate gql dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,7 @@ dependencies = [
     "base58 < 2.2.0, >=2.1.1",
     "Deprecated < 1.3.0, >=1.2.14",
     "pysui-fastcrypto >= 0.7.0",
-    "gql[httpx,websockets] >= 3.5.0",
-]
+    ]
 
 dynamic = ["version", "readme"]
 


### PR DESCRIPTION
  - Removed redundant gql[httpx,websockets] >= 3.5.0 from pyproject.toml
  - Preserved the newer version >= 4.0.0